### PR TITLE
추상 인증 필터 (+ JwtUsernamePasswordAuthenticationFilter) 클래스 구현

### DIFF
--- a/src/main/java/org/swmaestro/kauth/authentication/AbstractAuthenticationFilter.java
+++ b/src/main/java/org/swmaestro/kauth/authentication/AbstractAuthenticationFilter.java
@@ -1,0 +1,73 @@
+package org.swmaestro.kauth.authentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.filter.GenericFilterBean;
+
+
+/**
+ * 기본 인증 필터
+ * @author ChangEn Yea
+ */
+public abstract class AbstractAuthenticationFilter extends GenericFilterBean {
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    protected final AuthenticationManager authenticationManager;
+
+    protected final AntPathRequestMatcher requestMatcher;
+
+    protected AbstractAuthenticationFilter(AuthenticationManager authenticationManager, AntPathRequestMatcher requestMatcher) {
+        this.authenticationManager = authenticationManager;
+        this.requestMatcher = requestMatcher;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        if(requestMatcher.matches((HttpServletRequest) request)) {
+            doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+        } else {
+            chain.doFilter(request, response);
+        }
+
+    }
+
+    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        try {
+            Authentication authenticationResult = attemptAuthentication(request, response);
+
+            successfulAuthentication(request, response, chain, authenticationResult);
+        } catch (InternalAuthenticationServiceException failed) {
+            super.logger.error("An internal error occurred while trying to authenticate the user.", failed);
+        } catch (AuthenticationException ex) {
+            unsuccessfulAuthentication(request, response, ex);
+        }
+
+    }
+
+    public abstract Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+        throws AuthenticationException, IOException, ServletException;
+
+    protected abstract void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+        FilterChain chain, Authentication authResult) throws IOException, ServletException;
+
+    protected abstract void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException failed) throws IOException, ServletException;
+
+
+}

--- a/src/main/java/org/swmaestro/kauth/authentication/AbstractUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/org/swmaestro/kauth/authentication/AbstractUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package org.swmaestro.kauth.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.swmaestro.kauth.dto.UsernamePasswordLoginRequest;
+import org.swmaestro.kauth.util.KauthBeansProvider;
+
+/**
+ * username + password 인증 필터
+ * @author ChangEn Yea
+ */
+public abstract class AbstractUsernamePasswordAuthenticationFilter extends AbstractAuthenticationFilter {
+
+    protected AbstractUsernamePasswordAuthenticationFilter(AuthenticationManager authenticationManager,
+        AntPathRequestMatcher antPathRequestMatcher) {
+            super(authenticationManager, antPathRequestMatcher);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+        throws AuthenticationException, IOException, ServletException {
+            try {
+                ObjectMapper objectMapper = KauthBeansProvider.getObjectMapper();
+                UsernamePasswordLoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), UsernamePasswordLoginRequest.class);
+
+                return super.authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+            } catch (IOException e) {
+                super.logger.error(e);
+            }
+            return null;
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException failed) throws IOException, ServletException {
+
+//        TODO username + password 인증 실패 시 처리 (계정 잠금 등)
+    }
+
+
+}

--- a/src/main/java/org/swmaestro/kauth/authentication/JwtUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/org/swmaestro/kauth/authentication/JwtUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package org.swmaestro.kauth.authentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.swmaestro.kauth.util.JwtUtil;
+import org.swmaestro.kauth.util.KauthBeansProvider;
+
+/**
+ * 인증/인가 관리 전략 JWT,
+ * 로그인 방식 username/password
+ * 인증 필터
+ * @author ChangEn Yea
+ */
+public class JwtUsernamePasswordAuthenticationFilter extends
+    AbstractUsernamePasswordAuthenticationFilter {
+
+    private final JwtUtil jwtUtil = KauthBeansProvider.getJwtUtil();
+
+    public JwtUsernamePasswordAuthenticationFilter(AuthenticationManager authenticationManager, String pattern) {
+        super(authenticationManager, new AntPathRequestMatcher(pattern,"POST"));
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+        HttpServletResponse response, FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+
+        UserDetails user = (UserDetails) authResult;
+
+//        토큰 발급
+        String accessToken = jwtUtil.createAccessToken(user.getUsername());
+        String refreshToken = jwtUtil.createRefreshToken(user.getUsername());
+
+//        TODO: RefreshToken 저장
+
+//        TODO: HttpServletResponse에 토큰 담아서 response
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/dto/UsernamePasswordLoginRequest.java
+++ b/src/main/java/org/swmaestro/kauth/dto/UsernamePasswordLoginRequest.java
@@ -1,0 +1,30 @@
+package org.swmaestro.kauth.dto;
+
+/**
+ * username + password 로그인 요청 body
+ * @author ChangEn Yea
+ */
+public class UsernamePasswordLoginRequest {
+
+    private String username;
+
+    private String password;
+
+    public UsernamePasswordLoginRequest() {}
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}


### PR DESCRIPTION
### 한 줄 설명

추상 인증 필터 (+ JwtUsernamePasswordAuthenticationFilter) 클래스 구현

### 상세 설명
**dto.UsernamePasswordLoginRequest**: username + password 로그인 요청 body

**authentication.AbstractAuthenticationFilter**: GenericFilterBean을 상속하는 추상 인증 필터
- `public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)`: URL패턴과 HTTP 메소드 (POST)가 일치할 때 아래의 doFilter 메소드 호출
- `public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)`: attemptAuthentication 메소드 호출 후 결과에 따라 successfulAuthentication 또는 unsuccessfulAuthentication 메소드 호출

**authentication.AbstractUsernamePasswordAuthenticationFilter**: AbstractAuthenticationFilter를 상속하는 추상 username + password 인증 필터
- `public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)`: HttpServletRequest를 UsernamePasswordLoginRequest 클래스로 역직렬화하여 Spring Security AuthenticationManager 클래스의 authenticate 메소드에 넣고 호출
- `protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
        AuthenticationException failed)`: 인증 실패 시 처리 (계정 잠금 등) 메소드. **미구현**

**authentication.JwtUsernamePasswordAuthenticationFilter**: AbstractUsernamePasswordAuthenticationFilter를 상속하는 인증/인가 전략 JWT일 때의 인증 필터
- `protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult)`: 인증 성공 시 처리 메소드 (토큰 발급, 토큰 DB 저장, HttpServletResponse 객체 조작 등) **미구현**
