### PR TITLE
Kauth 설정 시작 점 추상 클래스 (+JWT) 구현

### DIFF
--- a/src/main/java/org/swmaestro/kauth/core/JwtConfigurer.java
+++ b/src/main/java/org/swmaestro/kauth/core/JwtConfigurer.java
@@ -1,0 +1,41 @@
+package org.swmaestro.kauth.core;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.savedrequest.RequestCacheAwareFilter;
+import org.swmaestro.kauth.authentication.JwtUsernamePasswordAuthenticationFilter;
+
+
+/**
+ * 인증/인가 전략: JWT
+ * @author ChangEn Yea
+ */
+public class JwtConfigurer extends KauthConfigurer {
+
+    private JwtConfigurer(HttpSecurity http) throws Exception {
+        super.http = http;
+        super.authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        super.setStatelessSession();
+        super.setFormLoginDisable();
+    }
+
+    public static JwtConfigurer init(HttpSecurity http) throws Exception {
+        return new JwtConfigurer(http);
+    }
+
+//    TODO 로그인 방식 선택 (username + password, oauth, rememberMe)
+    public JwtConfigurer selectLoginProvider() {
+
+        return this;
+    }
+
+    public void UsernamePassword(String pattern) {
+        super.addFilterBefore(new JwtUsernamePasswordAuthenticationFilter(
+            super.authenticationManager, pattern), RequestCacheAwareFilter.class);
+    }
+
+    @Override
+    public HttpSecurity complete() {
+        return super.http;
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/core/KauthConfigurer.java
+++ b/src/main/java/org/swmaestro/kauth/core/KauthConfigurer.java
@@ -1,0 +1,39 @@
+package org.swmaestro.kauth.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.Filter;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+/**
+ * Kauth 설정 시작 점, 인증/인가 전략 선택
+ * @author ChangEn Yea
+ */
+public abstract class KauthConfigurer {
+
+    protected HttpSecurity http;
+
+    protected UserDetailsService userDetailsService;
+
+    protected ObjectMapper objectMapper;
+
+    protected AuthenticationManager authenticationManager;
+
+    protected void setStatelessSession() throws Exception {
+        this.http.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    }
+
+    protected void setFormLoginDisable() throws Exception {
+        this.http.formLogin(AbstractHttpConfigurer::disable);
+    }
+
+    public abstract HttpSecurity complete();
+
+    protected void addFilterBefore(Filter filter,  Class<? extends Filter> beforeFilter) {
+        this.http.addFilterBefore(filter, beforeFilter);
+    }
+
+}

--- a/src/main/java/org/swmaestro/kauth/core/KauthConfigurer.java
+++ b/src/main/java/org/swmaestro/kauth/core/KauthConfigurer.java
@@ -1,12 +1,10 @@
 package org.swmaestro.kauth.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.Filter;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 
 /**
  * Kauth 설정 시작 점, 인증/인가 전략 선택
@@ -15,10 +13,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 public abstract class KauthConfigurer {
 
     protected HttpSecurity http;
-
-    protected UserDetailsService userDetailsService;
-
-    protected ObjectMapper objectMapper;
 
     protected AuthenticationManager authenticationManager;
 

--- a/src/main/java/org/swmaestro/kauth/test/SecurityConfiguration.java
+++ b/src/main/java/org/swmaestro/kauth/test/SecurityConfiguration.java
@@ -1,0 +1,27 @@
+package org.swmaestro.kauth.test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.swmaestro.kauth.core.JwtConfigurer;
+
+/**
+ * TODO Release전에 지워야 함
+ * 테스트 용
+ */
+@Configuration
+@EnableWebSecurity(debug = true)
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        JwtConfigurer.init(http).complete();
+
+        return http.build();
+    }
+
+
+}


### PR DESCRIPTION
### 한 줄 설명

Kauth 설정 시작 점 추상 클래스 (+JWT) 구현

### 상세 설명

**core.KauthConfigurer**: 인증/인가 전략을 선택하는 설정 시작 점 추상 클래스
- `protected void setStatelessSession()`: HttpSecurity의 session stateless 설정
- `protected void setFormLoginDisable()`: HttpSecurity의 form login disable 설정
- `protected void addFilterBefore(Filter filter,  Class<? extends Filter> beforeFilter)`: HttpSecurity에 필터 추가

**core.JwtConfigurer**: JWT 인증/인가 전략의 설정 시작 점 클래스
- `public static JwtConfigurer init(HttpSecurity http)`: JWT 인증/인가 전략 설정 시작 점 메소드
- `public JwtConfigurer selectLoginProvider()`: 로그인 방식 선택 (username + password, oauth, rememberMe) **미구현**
- `public void UsernamePassword(String pattern)` username + password 로그인 방식 활성화
- `public HttpSecurity complete()`: 설정 체이닝 완료 메서드. HttpSecurity 반환.

**test.SecurityConfiguration**: 스프링 시큐리티 필터 체인에 kauth 적용해서 테스트 하는 용도
