### PR TITLE
HttpServletResponse 처리 서비스 구현

### DIFF
--- a/src/main/java/org/swmaestro/kauth/util/ErrorResponse.java
+++ b/src/main/java/org/swmaestro/kauth/util/ErrorResponse.java
@@ -1,0 +1,6 @@
+package org.swmaestro.kauth.util;
+
+public record ErrorResponse(
+    String message
+) {
+}

--- a/src/main/java/org/swmaestro/kauth/util/HttpServletResponseUtil.java
+++ b/src/main/java/org/swmaestro/kauth/util/HttpServletResponseUtil.java
@@ -1,0 +1,60 @@
+package org.swmaestro.kauth.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import java.io.IOException;
+
+public class HttpServletResponseUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // setHeader sets header in HttpServletResponse
+    public static void setHeader(HttpServletResponse response, String name, String value) {
+        response.setHeader(name, value);
+    }
+
+    // setJsonBody sets json body in HttpServletResponse
+    public static void setJsonBody(HttpServletResponse response, Object body) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String responseBody = objectMapper.writeValueAsString(body);
+
+        response.getWriter().write(responseBody);
+    }
+
+    // setUnauthorizedResponse sets 401 Unauthorized response in HttpServletResponse
+    public static void setUnauthorizedResponse(HttpServletResponse response, Exception exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String responseBody = objectMapper.writeValueAsString(exception);
+
+        response.getWriter().write(responseBody);
+    }
+
+    // setCookie sets cookie in HttpServletResponse
+    public static void setCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            String path,
+            int maxAge,
+            String domain,
+            Cookie.SameSite sameSite
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path(path)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(maxAge)
+                .sameSite(sameSite.toString())
+                .domain(domain)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/util/HttpServletResponseUtil.java
+++ b/src/main/java/org/swmaestro/kauth/util/HttpServletResponseUtil.java
@@ -5,20 +5,26 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Component
 public class HttpServletResponseUtil {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
+
+    public HttpServletResponseUtil(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     // setHeader sets header in HttpServletResponse
-    public static void setHeader(HttpServletResponse response, String name, String value) {
+    public void setHeader(HttpServletResponse response, String name, String value) {
         response.setHeader(name, value);
     }
 
     // setJsonBody sets json body in HttpServletResponse
-    public static void setJsonBody(HttpServletResponse response, Object body) throws IOException {
+    public void setJsonBody(HttpServletResponse response, Object body) throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
@@ -28,7 +34,7 @@ public class HttpServletResponseUtil {
     }
 
     // setUnauthorizedResponse sets 401 Unauthorized response in HttpServletResponse
-    public static void setUnauthorizedResponse(HttpServletResponse response, Exception exception) throws IOException {
+    public void setUnauthorizedResponse(HttpServletResponse response, Exception exception) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
         String responseBody = objectMapper.writeValueAsString(exception);
@@ -37,7 +43,7 @@ public class HttpServletResponseUtil {
     }
 
     // setCookie sets cookie in HttpServletResponse
-    public static void setCookie(
+    public void setCookie(
             HttpServletResponse response,
             String name,
             String value,

--- a/src/test/java/org/swmaestro/kauth/util/HttpServletResponseUtilTest.java
+++ b/src/test/java/org/swmaestro/kauth/util/HttpServletResponseUtilTest.java
@@ -1,0 +1,92 @@
+package org.swmaestro.kauth.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.swmaestro.kauth.dto.UsernamePasswordLoginRequest;
+
+import java.io.IOException;
+
+class HttpServletResponseUtilTest {
+
+    @DisplayName("헤더 설정 테스트")
+    @Test
+    void setHeader() {
+        HttpServletResponse response = new MockHttpServletResponse();
+
+        HttpServletResponseUtil.setHeader(response, "name", "value");
+
+        Assertions.assertEquals("value", response.getHeader("name"));
+    }
+
+    @DisplayName("JSON body 설정 테스트")
+    @Test
+    void setJsonBody() throws IOException {
+        UsernamePasswordLoginRequest loginRequest = new UsernamePasswordLoginRequest();
+        loginRequest.setUsername("username");
+        loginRequest.setPassword("password");
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        HttpServletResponseUtil.setJsonBody(responseWrapper, loginRequest);
+
+        byte[] contentAsByteArray = responseWrapper.getContentAsByteArray();
+        String responseStr = new String(contentAsByteArray, responseWrapper.getCharacterEncoding());
+        UsernamePasswordLoginRequest responseLoginRequest = new ObjectMapper().readValue(responseStr, UsernamePasswordLoginRequest.class);
+
+        Assertions.assertEquals("application/json;charset=UTF-8", response.getContentType());
+        Assertions.assertEquals("UTF-8", response.getCharacterEncoding());
+        Assertions.assertEquals("username", responseLoginRequest.getUsername());
+        Assertions.assertEquals("password", responseLoginRequest.getPassword());
+    }
+
+    @DisplayName("401 응답 설정 테스트")
+    @Test
+    void setUnauthorizedResponse() throws IOException {
+        RuntimeException exception = new RuntimeException("unauthorized");
+
+        HttpServletResponse response = new MockHttpServletResponse();
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        HttpServletResponseUtil.setUnauthorizedResponse(responseWrapper, exception);
+
+        byte[] contentAsByteArray = responseWrapper.getContentAsByteArray();
+        String responseStr = new String(contentAsByteArray, responseWrapper.getCharacterEncoding());
+        RuntimeException responseException = new ObjectMapper().readValue(responseStr, RuntimeException.class);
+
+        Assertions.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+        Assertions.assertEquals("unauthorized", responseException.getMessage());
+    }
+
+    @DisplayName("Response Cookie 설정 테스트")
+    @Test
+    void setCookie() {
+        HttpServletResponse response = new MockHttpServletResponse();
+
+        HttpServletResponseUtil.setCookie(
+                response,
+                "refresh_token",
+                "token",
+                "/",
+                3600,
+                "localhost",
+                Cookie.SameSite.NONE
+        );
+
+        String responseCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+
+        Assertions.assertNotNull(responseCookie);
+        Assertions.assertTrue(responseCookie.contains("refresh_token=token"));
+        Assertions.assertTrue(responseCookie.contains("Path=/"));
+        Assertions.assertTrue(responseCookie.contains("Expires="));
+        Assertions.assertTrue(responseCookie.contains("Domain=localhost"));
+        Assertions.assertTrue(responseCookie.contains("SameSite=NONE"));
+    }
+}

--- a/src/test/java/org/swmaestro/kauth/util/HttpServletResponseUtilTest.java
+++ b/src/test/java/org/swmaestro/kauth/util/HttpServletResponseUtilTest.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -13,14 +15,18 @@ import org.swmaestro.kauth.dto.UsernamePasswordLoginRequest;
 
 import java.io.IOException;
 
+@SpringBootTest
 class HttpServletResponseUtilTest {
+
+    @Autowired
+    private HttpServletResponseUtil httpServletResponseUtil;
 
     @DisplayName("헤더 설정 테스트")
     @Test
     void setHeader() {
         HttpServletResponse response = new MockHttpServletResponse();
 
-        HttpServletResponseUtil.setHeader(response, "name", "value");
+        httpServletResponseUtil.setHeader(response, "name", "value");
 
         Assertions.assertEquals("value", response.getHeader("name"));
     }
@@ -35,7 +41,7 @@ class HttpServletResponseUtilTest {
         HttpServletResponse response = new MockHttpServletResponse();
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
-        HttpServletResponseUtil.setJsonBody(responseWrapper, loginRequest);
+        httpServletResponseUtil.setJsonBody(responseWrapper, loginRequest);
 
         byte[] contentAsByteArray = responseWrapper.getContentAsByteArray();
         String responseStr = new String(contentAsByteArray, responseWrapper.getCharacterEncoding());
@@ -55,7 +61,7 @@ class HttpServletResponseUtilTest {
         HttpServletResponse response = new MockHttpServletResponse();
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
-        HttpServletResponseUtil.setUnauthorizedResponse(responseWrapper, exception);
+        httpServletResponseUtil.setUnauthorizedResponse(responseWrapper, exception);
 
         byte[] contentAsByteArray = responseWrapper.getContentAsByteArray();
         String responseStr = new String(contentAsByteArray, responseWrapper.getCharacterEncoding());
@@ -70,7 +76,7 @@ class HttpServletResponseUtilTest {
     void setCookie() {
         HttpServletResponse response = new MockHttpServletResponse();
 
-        HttpServletResponseUtil.setCookie(
+        httpServletResponseUtil.setCookie(
                 response,
                 "refresh_token",
                 "token",


### PR DESCRIPTION
### 한 줄 설명

<!--
PR을 간략하게 한 줄로 설명해주세요.
-->

HttpServletResponse 처리 서비스를 구현하였습니다.

### 상세 설명

<!--
PR에 대한 상세 설명을 적어주세요.

- **이 PR의 배경 설명**
- **이 PR이 해결하는 문제**
- **이 PR이 변경하는 요소들**
-->

`util/HttpServletResponseUtil`: HttpServletResponse 인스턴스를 받아 다음과 같은 설정을 response에 추가해주는 유틸리티 서비스
- `setHeader()`: response에 추가 헤더 설정
- `setJsonBody()`: response에 JSON body 설정
- `setUnauthorizedResponse()`: response에 401 Unauthorized 설정
- `setCookie()`: response에 쿠키 설정

### 관련 이슈

<!--
관련된 이슈가 있다면 이곳에 적어주세요.

ex: #123
-->

이슈 #

### 추가 사항

<!--
PR과 관련된 추가적인 사항이 있다면 이곳에 적어주세요.

- **리뷰어에게 전달할 내용**
- **PR과 관련된 스크린샷**
- **PR과 관련된 레퍼런스**
-->

`test/util/HttpServletResponseUtilTest`에 유닛 테스트가 포함되어 있습니다.