### PR TITLE
Feat: OAuth2.0 kakao, naver, google 기능을 위한 OAuth2User, service 구현체 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,9 @@ repositories {
 }
 
 dependencies {
+
+
+
 //    Persistence
 //    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 //    implementation("org.springframework.boot:spring-boot-starter-data-redis")
@@ -27,7 +30,7 @@ dependencies {
 
 //    Oauth 2.0
 //    implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
-//    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 //    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/java/org/swmaestro/kauth/oauth/entity/KauthUserPrincipal.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/entity/KauthUserPrincipal.java
@@ -1,0 +1,39 @@
+package org.swmaestro.kauth.oauth.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * UserPrincipal 에 도메인 모델을 주입해 도메인 모델 접근이 용이하도록 하는 추상 클래스
+ * 추상 클래스 KauthUserPrincipal 을 상속하고 사용자가 정의한 도메인 모델에 맞게 메소드를 재정의
+ * <M> : 유저(멤버) 도메인 모델
+ * @author pyo
+ * @param <M>
+ */
+public abstract class KauthUserPrincipal<M> implements OAuth2User, UserDetails {
+
+    private M member;
+    private Map<String, Object> attributes;
+
+    /**
+     * 일반 로그인 했을 때의 UserPrincipal
+     * @param member
+     */
+    public KauthUserPrincipal(M member) {
+        this.member = member;
+    }
+
+    /**
+     * 소셜 로그인 했을 때의 UserPrincipal
+     * @param member
+     * @param attributes
+     */
+    public KauthUserPrincipal(M member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/OAuth2UserInfo.java
@@ -1,0 +1,27 @@
+package org.swmaestro.kauth.oauth.info;
+
+import java.util.Map;
+
+/**
+ * OAuth2 로그인으로 얻은 사용자 정보를 나타낸 abstract class
+ * @author pyo
+ */
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/OAuth2UserInfoFactory.java
@@ -1,0 +1,23 @@
+package org.swmaestro.kauth.oauth.info;
+
+import org.swmaestro.kauth.oauth.info.provider.ProviderType;
+import org.swmaestro.kauth.oauth.info.provider.GoogleOAuth2UserInfo;
+import org.swmaestro.kauth.oauth.info.provider.KakaoOAuth2UserInfo;
+import org.swmaestro.kauth.oauth.info.provider.NaverOAuth2UserInfo;
+
+import java.util.Map;
+
+/**
+ * OAuth Provider 별로 사용자 정보를 반환하는 Factory Class
+ * @author pyo
+ */
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+        switch (providerType) {
+            case GOOGLE: return new GoogleOAuth2UserInfo(attributes);
+            case NAVER: return new NaverOAuth2UserInfo(attributes);
+            case KAKAO: return new KakaoOAuth2UserInfo(attributes);
+            default: throw new IllegalArgumentException("Unsupported Provider Type");
+        }
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/provider/GoogleOAuth2UserInfo.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/provider/GoogleOAuth2UserInfo.java
@@ -1,0 +1,54 @@
+package org.swmaestro.kauth.oauth.info.provider;
+
+import org.swmaestro.kauth.oauth.info.OAuth2UserInfo;
+
+import java.util.Map;
+
+/**
+ * 구글 OAuth2 로그인을 통해 얻을 수 있는 유저 정보 구현체
+ * @author pyo
+ */
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    /**
+     * 사용자 등록번호 반환
+     * @return (String) "12345678"
+     */
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    /**
+     * 사용자 이름 반환(실제 이름이 아닐 수 있음)
+     * @return (String) "길동이"
+     */
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+
+    /**
+     * 등록된 사용자 이메일을 반환
+     * @return (String) "example@ex.com"
+     */
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    /**
+     * 사용자 프로필 이미지 URL 반환
+     * 기본 프로필 이미지일 경우 이름 첫 글자로 된 랜덤 이미지 URL이 반환된다.
+     * @return (String) "http://yyy.google.com/.../img_640x640.jpg"
+     */
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/provider/KakaoOAuth2UserInfo.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/provider/KakaoOAuth2UserInfo.java
@@ -1,0 +1,179 @@
+package org.swmaestro.kauth.oauth.info.provider;
+
+import org.swmaestro.kauth.oauth.info.OAuth2UserInfo;
+
+import java.util.Map;
+
+
+/**
+ * 카카오 OAuth2 로그인을 통해 얻을 수 있는 유저 정보 구현체
+ * @author pyo
+ */
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    private Map<String, Object> kakaoAccount;
+    private Map<String, Object> profile;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+        this.kakaoAccount = (Map) attributes.get("kakao_account");
+        this.profile = (Map) kakaoAccount.get("profile");
+    }
+
+    /**
+     * 카카오에 등록된 회원번호 반환
+     * @return (String) "q1w2e3r4"
+     */
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    /**
+     * 카카오에 등록된 사용자의 실제 이름을 반환
+     * @return (String) "홍길동"
+     */
+    @Override
+    public String getName() {
+        boolean nameNeedsAgreement = (boolean) kakaoAccount.get("name_needs_agreement");
+        if (nameNeedsAgreement) {
+            return (String) kakaoAccount.get("name");
+        }
+        return null;
+    }
+
+    /**
+     * 카카오계정 이메일 반환
+     * @return (String) "example@ex.com"
+     */
+    @Override
+    public String getEmail() {
+        boolean emailNeedsAgreement = (boolean) kakaoAccount.get("email_needs_agreement");
+        if (emailNeedsAgreement) {
+            boolean isEmailValid = (boolean) kakaoAccount.get("is_email_valid");
+            boolean isEmailVerified = (boolean) kakaoAccount.get("is_email_verified");
+            if (isEmailValid && isEmailVerified) {
+                return (String) kakaoAccount.get("email");
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 카카오 프로필 이미지 URL 반환
+     * 기본 프로필 이미지일 경우 null 반환
+     * @return (String) "http://yyy.kakao.com/dn/.../img_640x640.jpg"
+     */
+    @Override
+    public String getImageUrl() {
+        boolean profileImageNeedsAgreement = (boolean) kakaoAccount.get("profile_image_needs_agreement");
+        if (profileImageNeedsAgreement) {
+            if (!(boolean) profile.get("is_default_image")) {
+                return (String) profile.get("profile_image_url");
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 카카오 프로필 썸네일 이미지 URL 반환 (작은 크기)
+     * 기본 프로필 이미지일 경우 null 반환
+     * @return (String) "http://yyy.kakao.com/.../img_110x110.jpg"
+     */
+    public String getThumbnailImageUrl() {
+        boolean profileImageNeedsAgreement = (boolean) kakaoAccount.get("profile_image_needs_agreement");
+        if (profileImageNeedsAgreement) {
+            if (!(boolean) profile.get("is_default_image")) {
+                return (String) profile.get("thumbnail_image_url");
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 사용자가 설정한 카카오 닉네임 반환
+     * @return (String) "길동이"
+     */
+    public String getNickname() {
+        boolean profileNicknameNeedsAgreement = (boolean) kakaoAccount.get("profile_nickname_needs_agreement");
+        if (profileNicknameNeedsAgreement) {
+            return (String) profile.get("nickname");
+        }
+        return null;
+    }
+
+    /**
+     * 사용자의 연령대를 반환
+     * 20대 -> "20~29"
+     * @return (String) "20~29"
+     */
+    public String getAgeRange() {
+        boolean ageRangeNeedsAgreement = (boolean) kakaoAccount.get("age_range_needs_agreement");
+        if (ageRangeNeedsAgreement) {
+            return (String) kakaoAccount.get("age_range");
+        }
+        return null;
+    }
+
+    /**
+     * 생일을 "MMDD" 형태로 반환
+     * @return (String) "1130"
+     */
+    public String getBirthday() {
+        boolean birthdayNeedsAgreement = (boolean) kakaoAccount.get("birthday_needs_agreement");
+        if (birthdayNeedsAgreement) {
+            return (String) kakaoAccount.get("birthday");
+        }
+        return null;
+    }
+
+    /**
+     * 생일 타입을 반환
+     * SOLAR(양력) 또는 LUNAR(음력)
+     * @return (String) "SOLAR"
+     */
+    public String getBirthdayType() {
+        boolean birthdayNeedsAgreement = (boolean) kakaoAccount.get("birthday_needs_agreement");
+        if (birthdayNeedsAgreement) {
+            return (String) kakaoAccount.get("birthday_type");
+        }
+        return null;
+    }
+
+    /**
+     * 출생연도를 "YYYY" 형태로 반환
+     * @return (String) "2022"
+     */
+    public String getBirthyear() {
+        boolean birthyearNeedsAgreement = (boolean) kakaoAccount.get("birthyear_needs_agreement");
+        if (birthyearNeedsAgreement) {
+            return (String) kakaoAccount.get("birthyear");
+        }
+        return null;
+    }
+
+    /**
+     * 성별을 반환
+     * female(여자) 또는 male(남자)
+     * @return (String) "female"
+     */
+    public String getGender() {
+        boolean genderNeedsAgreement = (boolean) kakaoAccount.get("gender_needs_agreement");
+        if (genderNeedsAgreement) {
+            return (String) kakaoAccount.get("gender");
+        }
+        return null;
+    }
+
+    /**
+     * 전화번호 반환
+     * @return (String) "+82 010-1234-5678"
+     */
+    public String getPhoneNumber() {
+        boolean phoneNumberNeedsAgreement = (boolean) kakaoAccount.get("phone_number_needs_agreement");
+        if (phoneNumberNeedsAgreement) {
+            return (String) kakaoAccount.get("phone_number");
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/provider/NaverOAuth2UserInfo.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/provider/NaverOAuth2UserInfo.java
@@ -1,0 +1,147 @@
+package org.swmaestro.kauth.oauth.info.provider;
+
+import org.swmaestro.kauth.oauth.info.OAuth2UserInfo;
+
+import java.util.Map;
+
+/**
+ * 네이버 OAuth2 로그인을 통해 얻을 수 있는 유저 정보 구현체
+ * @author pyo
+ */
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    Map<String, Object> response;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+        response = (Map<String, Object>) attributes.get("response");
+    }
+
+    /**
+     * 네이버에 등록된 사용자 회원 번호 반환
+     * @return (String) "12345678"
+     */
+    @Override
+    public String getId() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("id");
+    }
+
+    /**
+     * 사용자 실제 이름 반환
+     * @return (String) "홍길동"
+     */
+    @Override
+    public String getName() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("name");
+    }
+
+    /**
+     * 사용자가 네이버에 등록한 이메일 반환
+     * @return (String) "example@ex.com"
+     */
+    @Override
+    public String getEmail() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("email");
+    }
+
+    /**
+     * 사용자 프로필 사진 URL 반환
+     * @return (String) "https://ssl.pstatic.net/.../nodata_33x33.gif"
+     */
+    @Override
+    public String getImageUrl() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+
+    /**
+     * 사용자가 등록한 네이버 닉네임 반환
+     * 닉네임을 등록하지 않았으면 "id***" 형태로 반환
+     * @return (String) "길동이"
+     */
+    public String getNickname() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("nickname");
+    }
+
+
+    /**
+     * 사용자 연령대를 반환
+     * 20대 -> "20-29"
+     * @return (String) "20-29"
+     */
+    public String getAgeRange() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("age");
+    }
+
+    /**
+     * 성별 반환
+     * F(여자), M(남자), U(확인불가)
+     * @return (String) "F"
+     */
+    public String getGender() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("gender");
+    }
+
+    /**
+     * 사용자 생일을 "MM-DD" 형태로 반환
+     * @return (String) "10-01"
+     */
+    public String getBirthday() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("birthday");
+    }
+
+    /**
+     * 출생 연도를 "YYYY" 형태로 반환
+     * @return (String) "1999"
+     */
+    public String getBirthyear() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("birthyear");
+    }
+
+    /**
+     * 사용자 휴대폰 번호 반환
+     * @return (String) "010-1234-5678"
+     */
+    public String getPhoneNumber() {
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("mobile");
+    }
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/info/provider/ProviderType.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/info/provider/ProviderType.java
@@ -1,0 +1,9 @@
+package org.swmaestro.kauth.oauth.info.provider;
+
+/**
+ * 제공하는 OAuth2 서비스 Provider Enum
+ * @author pyo
+ */
+public enum ProviderType {
+    GOOGLE, NAVER, KAKAO
+}

--- a/src/main/java/org/swmaestro/kauth/oauth/service/KOAuth2UserService.java
+++ b/src/main/java/org/swmaestro/kauth/oauth/service/KOAuth2UserService.java
@@ -1,0 +1,47 @@
+package org.swmaestro.kauth.oauth.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.swmaestro.kauth.oauth.entity.KauthUserPrincipal;
+import org.swmaestro.kauth.oauth.info.provider.ProviderType;
+import org.swmaestro.kauth.oauth.info.OAuth2UserInfo;
+import org.swmaestro.kauth.oauth.info.OAuth2UserInfoFactory;
+
+/**
+ * Provider 로부터 받은 OAuth2 유저(User) 정보를 기존 계정(Member)과 연계하여 처리(회원가입, 정보 갱신 등)하는 서비스
+ * 사용자는 이 클래스를 상속하는 Custom 서비스 클래스를 만들고
+ * processMemberByOAuth2UserInfo 메소드에 기존 계정(사용자가 정의한 멤버 도메인 모델)과 연계해서 처리하는 기능을 구현한다.
+ * <M> : 유저(멤버) 도메인 모델
+ * @author pyo
+ */
+public abstract class KOAuth2UserService extends DefaultOAuth2UserService {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User user = super.loadUser(userRequest);
+        OAuth2UserInfo oAuth2UserInfo = makeOAuth2UserInfoByProvider(userRequest, user);
+        return processMemberByOAuth2UserInfo(oAuth2UserInfo);
+    }
+
+    /**
+     * 로그인한 Provider 가 무엇인지 판별하고 그에 맞는 OAuth2UserInfo 를
+     * processMemberByOAuth2UserInfo 에 넘겨주는 메소드
+     * @param userRequest
+     * @param user
+     * @return (OAuth2UserInfo)
+     */
+    private OAuth2UserInfo makeOAuth2UserInfoByProvider(OAuth2UserRequest userRequest, OAuth2User user) {
+        ProviderType providerType = ProviderType.valueOf(
+                userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+
+        return OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+    }
+
+    /**
+     * OAuth2UserInfo 에서 얻은 정보를 바탕으로 기존 계정(Member)과 연계하여 처리(회원가입, 정보 갱신 등)하는 메소드
+     * @param oAuth2UserInfo
+     * @return (KauthUserPrincipal) 사용자가 정의한 멤버 모메인 모델과 OAuth2UserInfo의 attributes을 주입한 객체 반환
+     */
+    public abstract KauthUserPrincipal processMemberByOAuth2UserInfo(OAuth2UserInfo oAuth2UserInfo);
+}

--- a/src/main/resources/application-oauth.yaml
+++ b/src/main/resources/application-oauth.yaml
@@ -1,0 +1,42 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${CLIENT_ID_GOOGLE}
+            client-secret: ${CLIENT_SECRET_GOOGLE}
+            scope:
+              - email
+              - profile
+          naver:
+            client-id: ${CLIENT_ID_NAVER}
+            client-secret: ${CLIENT_SECRET_NAVER}
+            scope:
+              - name
+              - email
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            redirect-uri: ${HOST_DNS}/login/oauth2/code/naver
+          kakao:
+            client-id: ${CLIENT_ID_KAKAO}
+            client-secret: ${CLIENT_SECRET_KAKAO}
+            scope:
+              - profile_nickname
+              - profile_image
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            redirect-uri: ${HOST_DNS}/login/oauth2/code/kakao
+
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
### 한 줄 설명
OAuth2.0 [kakao, naver, google] 기능을 위한 OAuth2User, service 구현체 생성

### 상세 설명
- Provider 별 Attribute parsing 을 통한 `UserInfo` 클래스 생성
- 사용자가 정의할 멤버 도메인 모델이 주입된 `KauthUserPrincipal` 추상 클래스 생성
- 사용자 Repository와 연결된 멤버 관련 로직을 작성할 `KOAuthUserService` 추상 클래스 생성
    - 사용자는 `processMemberByOAuthUserInfo` 메소드를 구현하면 된다

### 관련 이슈
이슈: #7 

### 추가 사항

